### PR TITLE
Gnustep testplant branch tab fix

### DIFF
--- a/WinNSTabView.m
+++ b/WinNSTabView.m
@@ -68,16 +68,25 @@ static int _TabStateForThemeControlState(NSTabState state)
   HTHEME  hTheme = [self themeWithClassName: @"tab"];
   NSSize  size   = NSMakeSize(0, 17.0);
   if (hTheme == NULL)
-  {
-    // Default to GSTheme...
-    size.height = [super tabHeightForType: type];
-  }
+    {
+      // Default to GSTheme...
+      size.height = [super tabHeightForType: type];
+    }
   else
-  {
-    size = [self sizeForTheme: hTheme part: TABP_TABITEM state: TIS_NORMAL type: WIN32ThemeSizeBestFit];
-    [self releaseTheme: hTheme];
-  }
-  return MAX(8.0, size.height);
+    {
+      size = [self sizeForTheme: hTheme part: TABP_TABITEM state: TIS_NORMAL type: WIN32ThemeSizeBestFit];
+      [self releaseTheme: hTheme];
+
+      // Check for minimum as sometimes the windows theme is messed up for tab...
+      if ([[NSUserDefaults standardUserDefaults] objectForKey:@"GSMinimumTabHeight"])
+        {
+          CGFloat minimum = [[NSUserDefaults standardUserDefaults] floatForKey:@""];
+          NSDebugMLLog(@"WinNSTabView", @"size.height: %f minimum: %f", size.height, minimum);
+          size.height = MAX(size.height, minimum);
+        }
+    }
+  
+  return size.height;
 }
 
 - (void) drawTabViewRect: (NSRect)rect

--- a/WinNSTabView.m
+++ b/WinNSTabView.m
@@ -77,7 +77,7 @@ static int _TabStateForThemeControlState(NSTabState state)
     size = [self sizeForTheme: hTheme part: TABP_TABITEM state: TIS_NORMAL type: WIN32ThemeSizeBestFit];
     [self releaseTheme: hTheme];
   }
-  return size.height;
+  return MIN(17.0, size.height);
 }
 
 - (void) drawTabViewRect: (NSRect)rect

--- a/WinNSTabView.m
+++ b/WinNSTabView.m
@@ -78,6 +78,7 @@ static int _TabStateForThemeControlState(NSTabState state)
       [self releaseTheme: hTheme];
 
       // Check for minimum as sometimes the windows theme is messed up for tab...
+      // Initialized in -initialize method for WinUXTheme class...
       if ([[NSUserDefaults standardUserDefaults] objectForKey:@"GSMinimumTabHeight"])
         {
           CGFloat minimum = [[NSUserDefaults standardUserDefaults] floatForKey:@"GSMinimumTabHeight"];

--- a/WinNSTabView.m
+++ b/WinNSTabView.m
@@ -77,7 +77,7 @@ static int _TabStateForThemeControlState(NSTabState state)
     size = [self sizeForTheme: hTheme part: TABP_TABITEM state: TIS_NORMAL type: WIN32ThemeSizeBestFit];
     [self releaseTheme: hTheme];
   }
-  return MIN(17.0, size.height);
+  return MAX(8.0, size.height);
 }
 
 - (void) drawTabViewRect: (NSRect)rect

--- a/WinNSTabView.m
+++ b/WinNSTabView.m
@@ -80,9 +80,13 @@ static int _TabStateForThemeControlState(NSTabState state)
       // Check for minimum as sometimes the windows theme is messed up for tab...
       if ([[NSUserDefaults standardUserDefaults] objectForKey:@"GSMinimumTabHeight"])
         {
-          CGFloat minimum = [[NSUserDefaults standardUserDefaults] floatForKey:@""];
-          NSDebugMLLog(@"WinNSTabView", @"size.height: %f minimum: %f", size.height, minimum);
-          size.height = MAX(size.height, minimum);
+          CGFloat minimum = [[NSUserDefaults standardUserDefaults] floatForKey:@"GSMinimumTabHeight"];
+          
+          if (0.0 < minimum)
+            {
+              NSDebugMLLog(@"WinNSTabView", @"size.height: %f minimum: %f", size.height, minimum);
+              size.height = MAX(size.height, minimum);
+            }
         }
     }
   

--- a/WinUXTheme.m
+++ b/WinUXTheme.m
@@ -68,7 +68,8 @@ static inline RECT GSViewRectToWin(NSWindow *win, NSRect r)
   // Inserting WIN32VSImageRep class for themed images.
   [NSImageRep registerImageRepClass:[WIN32VSImageRep class]];
 
-
+  // See WinNSTabView.m for implemented usage...
+  [[NSUserDefaults standardUserDefaults] registerDefaults:@{@"GSMinimumTabHeight" : @12.0 }];
 }
 
 - (void) activate


### PR DESCRIPTION
Windows theming API sometimes returns some bogusly small height value for tab depending on the system configuration.  This fix sets and uses a minimum value to apply.  The default is set to 12.0 but can be overridden from the defaults via command line.