### PR TITLE
Remove calls to objc_(free, alloc)

### DIFF
--- a/WinUXTheme.m
+++ b/WinUXTheme.m
@@ -204,12 +204,12 @@ static inline RECT GSViewRectToWin(NSWindow *win, NSRect r)
   wchar_t* classNameChars;
   
   hWnd = (HWND)[[[NSView focusView] window] windowNumber];
-  classNameChars = objc_calloc([className length]+1, sizeof(wchar_t));
+  classNameChars = calloc([className length]+1, sizeof(wchar_t));
   [className getCharacters:classNameChars];
   
   hTheme = OpenThemeData(hWnd, classNameChars);
   
-  objc_free(classNameChars);
+  free(classNameChars);
   return hTheme;
 }
 


### PR DESCRIPTION
objc_free and objc_alloc is no longer accessible in Modern MSYS. This changes it to use the standard calloc and free calls which are effectively the same. 